### PR TITLE
Movement refactor and camera affected by delta time

### DIFF
--- a/FreeCam.cs
+++ b/FreeCam.cs
@@ -56,63 +56,38 @@ namespace ClassLibrary1
         /// </summary>
         private bool looking = false;
 
-        void Update()
+        private void Update()
         {
             var fastMode = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
-            var movementSpeed = fastMode ? this.fastMovementSpeed : this.movementSpeed;
+            var movementSpeed = fastMode ? fastMovementSpeed : this.movementSpeed;
 
-            if (Input.GetKey(KeyCode.A) || Input.GetKey(KeyCode.LeftArrow))
-            {
-                transform.position = transform.position + (-transform.right * movementSpeed * Time.deltaTime);
-            }
+            //Built in unity axis that map to A & Left Arrow for negative and D & Right Arrow for positive
+            float x = Input.GetAxis("Horizontal");
+            //Same here buth with W & Up Arrow and S & Down Arrow
+            float z = Input.GetAxis("Vertical");
 
-            if (Input.GetKey(KeyCode.D) || Input.GetKey(KeyCode.RightArrow))
-            {
-                transform.position = transform.position + (transform.right * movementSpeed * Time.deltaTime);
-            }
+            float y = 0;
+            if (Input.GetKeyDown(KeyCode.Q)) y = 1;
+            if (Input.GetKeyDown(KeyCode.E)) y = -1;
+            Vector3 movementDelta = new Vector3(x, y, z);
 
-            if (Input.GetKey(KeyCode.W) || Input.GetKey(KeyCode.UpArrow))
-            {
-                transform.position = transform.position + (transform.forward * movementSpeed * Time.deltaTime);
-            }
+            float globalUp = 0;
+            if(Input.GetKeyDown(KeyCode.R) || Input.GetKey(KeyCode.PageUp)) globalUp = 1;
+            if (Input.GetKey(KeyCode.F) || Input.GetKey(KeyCode.PageDown)) globalUp = -1;
 
-            if (Input.GetKey(KeyCode.S) || Input.GetKey(KeyCode.DownArrow))
-            {
-                transform.position = transform.position + (-transform.forward * movementSpeed * Time.deltaTime);
-            }
+            //Handle relative movement
+            transform.position += transform.right * movementSpeed * Time.deltaTime * movementDelta.x;
+            transform.position += transform.up * movementSpeed * Time.deltaTime * movementDelta.y;
+            transform.position += transform.forward * movementSpeed * Time.deltaTime * movementDelta.z;
 
-            if (Input.GetKey(KeyCode.Q))
-            {
-                transform.position = transform.position + (transform.up * movementSpeed * Time.deltaTime);
-            }
+            //Handle global up
+            transform.position += Vector3.up * movementSpeed * Time.deltaTime * globalUp;
 
-            if (Input.GetKey(KeyCode.E))
-            {
-                transform.position = transform.position + (-transform.up * movementSpeed * Time.deltaTime);
-            }
-
-            if (Input.GetKey(KeyCode.R) || Input.GetKey(KeyCode.PageUp))
-            {
-                transform.position = transform.position + (Vector3.up * movementSpeed * Time.deltaTime);
-            }
-
-            if (Input.GetKey(KeyCode.F) || Input.GetKey(KeyCode.PageDown))
-            {
-                transform.position = transform.position + (-Vector3.up * movementSpeed * Time.deltaTime);
-            }
-
-            if (looking)
-            {
-                float newRotationX = transform.localEulerAngles.y + Input.GetAxis("Mouse X") * freeLookSensitivity;
-                float newRotationY = transform.localEulerAngles.x - Input.GetAxis("Mouse Y") * freeLookSensitivity;
-                transform.localEulerAngles = new Vector3(newRotationY, newRotationX, 0f);
-            }
-
-            float axis = Input.GetAxis("Mouse ScrollWheel");
-            if (axis != 0 && !Editor.isInDropDown)
+            float scrollAxis = Input.GetAxis("Mouse ScrollWheel");
+            if (scrollAxis != 0 && !Editor.isInDropDown)
             {
                 var zoomSensitivity = fastMode ? this.fastZoomSensitivity : this.zoomSensitivity;
-                transform.position = transform.position + transform.forward * axis * zoomSensitivity;
+                transform.position = transform.position + transform.forward * scrollAxis * zoomSensitivity;
             }
             if (Input.GetKeyDown(KeyCode.Mouse1))
             {
@@ -121,6 +96,13 @@ namespace ClassLibrary1
             else if (Input.GetKeyUp(KeyCode.Mouse1))
             {
                 StopLooking();
+            }
+
+            if (looking)
+            {
+                float newRotationX = transform.localEulerAngles.y + Input.GetAxis("Mouse X") * freeLookSensitivity * Time.deltaTime;
+                float newRotationY = transform.localEulerAngles.x - Input.GetAxis("Mouse Y") * freeLookSensitivity * Time.deltaTime;
+                transform.localEulerAngles = new Vector3(newRotationY, newRotationX, 0f);
             }
         }
 


### PR DESCRIPTION
Refactored the movement code to remove all the if statements. Unable to test because I'm not sure how to compile non-.net framework class libraries but it should all work fine.

Camera movement has also been moved below the right click detection (Not really meaningful but you can move the camera one frame faster now) and is affected by Time.deltaTime. This will likely mean the sensitivity will need to be recalculated.